### PR TITLE
✨ Feat/#34 bottom view

### DIFF
--- a/Bbik.xcodeproj/project.pbxproj
+++ b/Bbik.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -215,6 +216,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Bbik/Source/View/ShopView.swift
+++ b/Bbik/Source/View/ShopView.swift
@@ -11,6 +11,16 @@ import SnapKit
 import Then
 
 final class ShopView: UIView {
+    let categoryscrollView = UIScrollView().then {
+        $0.showsHorizontalScrollIndicator = false // 수평 스크롤바 안보이게 설정
+        $0.showsVerticalScrollIndicator = false // 수직 스크롤바 안보이게 설정
+    }
+    let categorySteckView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .equalSpacing
+        $0.spacing = 12
+        $0.alignment = .center
+    }
 
 	lazy var shopCollectionView = UICollectionView(frame: .zero, collectionViewLayout: makeCollectionViewLayout()).then {
 		$0.backgroundColor = .systemBackground
@@ -28,6 +38,7 @@ final class ShopView: UIView {
 		super.init(frame: frame)
 
 		backgroundColor = .systemBackground
+        setCategoryViewUI()
 		setCollectionViewUI()
 		setPageControlUI()
 	}
@@ -36,11 +47,27 @@ final class ShopView: UIView {
 		fatalError("init(coder:) has not been implemented")
 	}
 
+    private func setCategoryViewUI() {
+        addSubview(categoryscrollView)
+        categoryscrollView.addSubview(categorySteckView)
+
+        categoryscrollView.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide)
+            make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(24)
+            make.height.equalTo(categorySteckView.snp.height)
+            make.bottom.equalTo(categorySteckView.snp.bottom)
+        }
+
+        categorySteckView.snp.makeConstraints { make in
+            make.directionalEdges.equalToSuperview()
+        }
+    }
+
 	private func setCollectionViewUI() {
 		addSubview(shopCollectionView)
 
 		shopCollectionView.snp.makeConstraints { make in
-			make.top.equalTo(self.safeAreaLayoutGuide)
+            make.top.equalTo(categorySteckView.snp.bottom)
 			make.leading.trailing.equalToSuperview().inset(24)
 			make.height.equalTo(shopCollectionView.snp.width).multipliedBy(1.5)
 		}
@@ -94,4 +121,24 @@ final class ShopView: UIView {
 
 		return UICollectionViewCompositionalLayout(section: section)
 	}
+
+    func setCategoryButtonsConfigure(_ categorys: [CategoryData]) {
+        categorySteckView.addArrangedSubview(createCategoryButton(title: "전체", tag: -1))
+
+        for (index, category) in categorys.enumerated() {
+            let button = createCategoryButton(title: category.category, tag: index)
+            categorySteckView.addArrangedSubview(button)
+        }
+    }
+
+    private func createCategoryButton(title: String, tag: Int) -> UIButton {
+        let button = UIButton().then {
+            $0.setTitle(title, for: .normal)
+            $0.titleLabel?.font = .boldSystemFont(ofSize: 16)
+            $0.titleLabel?.textAlignment = .center
+            $0.setTitleColor(.label, for: .normal)
+            $0.tag = tag
+        }
+        return button
+    }
 }

--- a/Bbik/Source/View/ShopView.swift
+++ b/Bbik/Source/View/ShopView.swift
@@ -26,17 +26,17 @@ final class ShopView: UIView {
         $0.backgroundColor = .separator
     }
 
-	lazy var shopCollectionView = UICollectionView(frame: .zero, collectionViewLayout: makeCollectionViewLayout()).then {
-		$0.backgroundColor = .systemBackground
-		$0.showsHorizontalScrollIndicator = false
-	}
+    lazy var shopCollectionView = UICollectionView(frame: .zero, collectionViewLayout: makeCollectionViewLayout()).then {
+        $0.backgroundColor = .systemBackground
+        $0.showsHorizontalScrollIndicator = false
+    }
 
-	let pageControl = UIPageControl().then {
-		$0.currentPage = 0
-		$0.pageIndicatorTintColor = UIColor(red: 179 / 255, green: 216 / 255, blue: 1.0, alpha: 1.0)
-		$0.currentPageIndicatorTintColor = .mainBlue
-		$0.isUserInteractionEnabled = true
-	}
+    let pageControl = UIPageControl().then {
+        $0.currentPage = 0
+        $0.pageIndicatorTintColor = UIColor(red: 179 / 255, green: 216 / 255, blue: 1.0, alpha: 1.0)
+        $0.currentPageIndicatorTintColor = .mainBlue
+        $0.isUserInteractionEnabled = true
+    }
 
     let bottomSeparatorView = UIView().then {
         $0.backgroundColor = .separator
@@ -83,19 +83,19 @@ final class ShopView: UIView {
         $0.textColor = .white
     }
 
-	override init(frame: CGRect) {
-		super.init(frame: frame)
+    override init(frame: CGRect) {
+        super.init(frame: frame)
 
-		backgroundColor = .systemBackground
+        backgroundColor = .systemBackground
         setCategoryViewUI()
-		setCollectionViewUI()
-		setPageControlUI()
+        setCollectionViewUI()
+        setPageControlUI()
         bottomCartStackViewUI()
-	}
+    }
 
-	required init?(coder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
-	}
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     private func setCategoryViewUI() {
         addSubview(categoryscrollView)
@@ -121,24 +121,24 @@ final class ShopView: UIView {
         }
     }
 
-	private func setCollectionViewUI() {
-		addSubview(shopCollectionView)
+    private func setCollectionViewUI() {
+        addSubview(shopCollectionView)
 
-		shopCollectionView.snp.makeConstraints { make in
+        shopCollectionView.snp.makeConstraints { make in
             make.top.equalTo(topSeparatorView.snp.bottom)
-			make.leading.trailing.equalToSuperview().inset(24)
-			make.height.equalTo(shopCollectionView.snp.width).multipliedBy(1.5)
-		}
-	}
+            make.leading.trailing.equalToSuperview().inset(24)
+            make.height.equalTo(shopCollectionView.snp.width).multipliedBy(1.5)
+        }
+    }
 
-	private func setPageControlUI() {
-		addSubview(pageControl)
+    private func setPageControlUI() {
+        addSubview(pageControl)
 
-		pageControl.snp.makeConstraints { make in
-			make.top.equalTo(shopCollectionView.snp.bottom).offset(16)
-			make.leading.trailing.equalToSuperview()
-		}
-	}
+        pageControl.snp.makeConstraints { make in
+            make.top.equalTo(shopCollectionView.snp.bottom).offset(16)
+            make.leading.trailing.equalToSuperview()
+        }
+    }
 
     private func bottomCartStackViewUI() {
         addSubview(bottomSeparatorView)
@@ -175,45 +175,45 @@ final class ShopView: UIView {
         }
     }
 
-	private func makeCollectionViewLayout() -> UICollectionViewLayout {
+    private func makeCollectionViewLayout() -> UICollectionViewLayout {
 
-		let itemSize = NSCollectionLayoutSize(
-			widthDimension: .fractionalWidth(0.5),
-			heightDimension: .fractionalHeight(1.0)
-		)
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.5),
+            heightDimension: .fractionalHeight(1.0)
+        )
 
-		let item = NSCollectionLayoutItem(layoutSize: itemSize)
-		item.contentInsets = NSDirectionalEdgeInsets(top: 9, leading: 9, bottom: 10, trailing: 10)
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        item.contentInsets = NSDirectionalEdgeInsets(top: 9, leading: 9, bottom: 10, trailing: 10)
 
-		let rowGroupSize = NSCollectionLayoutSize(
-			widthDimension: .fractionalWidth(1.0),
-			heightDimension: .fractionalHeight(1.0/3.0)
-		)
+        let rowGroupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0/3.0)
+        )
 
-		let rowGroup = NSCollectionLayoutGroup.horizontal(
-			layoutSize: rowGroupSize,
-			repeatingSubitem: item, count: 2
-		)
+        let rowGroup = NSCollectionLayoutGroup.horizontal(
+            layoutSize: rowGroupSize,
+            repeatingSubitem: item, count: 2
+        )
 
-		let pageGroupSize = NSCollectionLayoutSize(
-			widthDimension: .fractionalWidth(1.0),
-			heightDimension: .fractionalHeight(1.0)
-		)
+        let pageGroupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
 
-		let pageGroup = NSCollectionLayoutGroup.vertical(
-			layoutSize: pageGroupSize,
-			repeatingSubitem: rowGroup, count: 3
-		)
+        let pageGroup = NSCollectionLayoutGroup.vertical(
+            layoutSize: pageGroupSize,
+            repeatingSubitem: rowGroup, count: 3
+        )
 
-		let section = NSCollectionLayoutSection(group: pageGroup)
-		section.orthogonalScrollingBehavior = .groupPagingCentered
-		section.visibleItemsInvalidationHandler = { [weak self] _, offset, _ in
-			let pageIndex = round(offset.x / (self?.shopCollectionView.frame.width)!)
-			self?.pageControl.currentPage = Int(pageIndex)
-		}
+        let section = NSCollectionLayoutSection(group: pageGroup)
+        section.orthogonalScrollingBehavior = .groupPagingCentered
+        section.visibleItemsInvalidationHandler = { [weak self] _, offset, _ in
+            let pageIndex = round(offset.x / (self?.shopCollectionView.frame.width)!)
+            self?.pageControl.currentPage = Int(pageIndex)
+        }
 
-		return UICollectionViewCompositionalLayout(section: section)
-	}
+        return UICollectionViewCompositionalLayout(section: section)
+    }
 
     func setCategoryButtonsConfigure(_ categorys: [CategoryData]) {
         categoryStackView.addArrangedSubview(createCategoryButton(title: "전체", tag: -1))

--- a/Bbik/Source/View/ShopView.swift
+++ b/Bbik/Source/View/ShopView.swift
@@ -15,11 +15,15 @@ final class ShopView: UIView {
         $0.showsHorizontalScrollIndicator = false // 수평 스크롤바 안보이게 설정
         $0.showsVerticalScrollIndicator = false // 수직 스크롤바 안보이게 설정
     }
-    let categorySteckView = UIStackView().then {
+    let categoryStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.distribution = .equalSpacing
         $0.spacing = 12
         $0.alignment = .center
+    }
+
+    let topSeparatorView = UIView().then {
+        $0.backgroundColor = .separator
     }
 
 	lazy var shopCollectionView = UICollectionView(frame: .zero, collectionViewLayout: makeCollectionViewLayout()).then {
@@ -34,6 +38,51 @@ final class ShopView: UIView {
 		$0.isUserInteractionEnabled = true
 	}
 
+    let bottomSeparatorView = UIView().then {
+        $0.backgroundColor = .separator
+    }
+
+    let bottomStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.spacing = 12
+    }
+
+    let totalLabel = UILabel().then {
+        $0.font = .boldSystemFont(ofSize: 20)
+        $0.text = "0 원"
+    }
+
+    let cartButton = UIButton().then {
+        $0.backgroundColor = .mainBlue
+        $0.layer.cornerRadius = 8
+    }
+
+    let cartStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.alignment = .center
+        $0.spacing = 8
+        $0.alignment = .center
+        $0.distribution = .equalCentering
+        $0.isUserInteractionEnabled = false
+    }
+
+    let cartCountLabel = UILabel().then {
+        $0.font = .boldSystemFont(ofSize: 14)
+        $0.backgroundColor = .white
+        $0.textColor = .mainBlue
+        $0.text = "0"
+        $0.textAlignment = .center
+        $0.layer.cornerRadius = 10
+        $0.clipsToBounds = true
+    }
+
+    let cartLabel = UILabel().then {
+        $0.text = "장바구니 보기"
+        $0.font = .systemFont(ofSize: 16)
+        $0.textColor = .white
+    }
+
 	override init(frame: CGRect) {
 		super.init(frame: frame)
 
@@ -41,6 +90,7 @@ final class ShopView: UIView {
         setCategoryViewUI()
 		setCollectionViewUI()
 		setPageControlUI()
+        bottomCartStackViewUI()
 	}
 
 	required init?(coder: NSCoder) {
@@ -49,17 +99,25 @@ final class ShopView: UIView {
 
     private func setCategoryViewUI() {
         addSubview(categoryscrollView)
-        categoryscrollView.addSubview(categorySteckView)
+        categoryscrollView.addSubview(categoryStackView)
+
+        addSubview(topSeparatorView)
 
         categoryscrollView.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide)
             make.leading.trailing.equalTo(safeAreaLayoutGuide).inset(24)
-            make.height.equalTo(categorySteckView.snp.height)
-            make.bottom.equalTo(categorySteckView.snp.bottom)
+            make.height.equalTo(categoryStackView.snp.height)
+            make.bottom.equalTo(categoryStackView.snp.bottom)
         }
 
-        categorySteckView.snp.makeConstraints { make in
+        categoryStackView.snp.makeConstraints { make in
             make.directionalEdges.equalToSuperview()
+        }
+
+        topSeparatorView.snp.makeConstraints { make in
+            make.top.equalTo(categoryStackView.snp.bottom).offset(4)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(1) // 선의 두께
         }
     }
 
@@ -67,7 +125,7 @@ final class ShopView: UIView {
 		addSubview(shopCollectionView)
 
 		shopCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(categorySteckView.snp.bottom)
+            make.top.equalTo(topSeparatorView.snp.bottom)
 			make.leading.trailing.equalToSuperview().inset(24)
 			make.height.equalTo(shopCollectionView.snp.width).multipliedBy(1.5)
 		}
@@ -81,6 +139,41 @@ final class ShopView: UIView {
 			make.leading.trailing.equalToSuperview()
 		}
 	}
+
+    private func bottomCartStackViewUI() {
+        addSubview(bottomSeparatorView)
+        addSubview(bottomStackView)
+        bottomStackView.addArrangedSubview(totalLabel)
+        bottomStackView.addArrangedSubview(cartButton)
+
+        cartButton.addSubview(cartStackView)
+
+        cartStackView.addArrangedSubview(cartCountLabel)
+        cartStackView.addArrangedSubview(cartLabel)
+
+        bottomSeparatorView.snp.makeConstraints { make in
+            make.top.equalTo(pageControl.snp.bottom).offset(4)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(1) // 선의 두께
+        }
+
+        bottomStackView.snp.makeConstraints { make in
+            make.top.equalTo(bottomSeparatorView.snp.bottom).offset(16)
+            make.leading.trailing.equalToSuperview().inset(24)
+        }
+
+        cartButton.snp.makeConstraints { make in
+            make.height.equalTo(45)
+        }
+
+        cartStackView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+
+        cartCountLabel.snp.makeConstraints { make in
+            make.width.height.equalTo(20)
+        }
+    }
 
 	private func makeCollectionViewLayout() -> UICollectionViewLayout {
 
@@ -123,11 +216,11 @@ final class ShopView: UIView {
 	}
 
     func setCategoryButtonsConfigure(_ categorys: [CategoryData]) {
-        categorySteckView.addArrangedSubview(createCategoryButton(title: "전체", tag: -1))
+        categoryStackView.addArrangedSubview(createCategoryButton(title: "전체", tag: -1))
 
         for (index, category) in categorys.enumerated() {
             let button = createCategoryButton(title: category.category, tag: index)
-            categorySteckView.addArrangedSubview(button)
+            categoryStackView.addArrangedSubview(button)
         }
     }
 
@@ -140,5 +233,10 @@ final class ShopView: UIView {
             $0.tag = tag
         }
         return button
+    }
+
+    func updateCart(count: Int, price: Int) {
+        cartCountLabel.text = "\(count)"
+        totalLabel.text = "\(price)원"
     }
 }

--- a/Bbik/Source/ViewController/ViewController.swift
+++ b/Bbik/Source/ViewController/ViewController.swift
@@ -11,6 +11,8 @@ class ViewController: UIViewController {
     private let shopService = ShopDataService()
     private var selecteLanguage = Language.korean
     private var selectedMenu = -1
+    private var cartCount = 0
+    private var totalPrice: Int = 0
 
     let shopView = ShopView()
     var shopData = [CategoryData]()
@@ -56,6 +58,9 @@ extension ViewController: UICollectionViewDelegate {
             return
         }
 
+        cartCount += 1
+        totalPrice += shopItem.price
+        shopView.updateCart(count: cartCount, price: totalPrice)
         print("touch \(shopItem.name)")
     }
 }
@@ -96,7 +101,7 @@ extension ViewController {
         }
     // 카테고리 버튼에 액션을 연결하고, 현재 선택된 메뉴 상태를 초기 설정
     private func setupCategoryButtons() {
-            shopView.categorySteckView.arrangedSubviews.forEach {
+            shopView.categoryStackView.arrangedSubviews.forEach {
                 guard let button = $0 as? UIButton else { return }
                 button.addTarget(self, action: #selector(categoryButtonTapped(_:)), for: .touchUpInside)
             }
@@ -113,10 +118,10 @@ extension ViewController {
 
     // 선택된 카테고리 버튼의 텍스트 색상을 변경
     private func updateCategorySelection(for tag: Int) {
-        shopView.categorySteckView.arrangedSubviews.forEach {
+        shopView.categoryStackView.arrangedSubviews.forEach {
             guard let button = $0 as? UIButton else { return }
             let isSelected = (button.tag == tag)
-            button.setTitleColor(isSelected ? .systemBlue : .label, for: .normal)
+            button.setTitleColor(isSelected ? .mainBlue : .label, for: .normal)
         }
     }
 }

--- a/Bbik/Source/ViewController/ViewController.swift
+++ b/Bbik/Source/ViewController/ViewController.swift
@@ -66,10 +66,6 @@ extension ViewController: UICollectionViewDelegate {
 }
 
 extension ViewController {
-    private func makecategoryButtons() {
-        shopView.setCategoryButtonsConfigure(shopData)
-    }
-
     // 전체 카테고리 처리를 위한 함수
     private func updateSelectedMenuData() {
         if selectedMenu == -1 {

--- a/Bbik/Source/ViewController/ViewController.swift
+++ b/Bbik/Source/ViewController/ViewController.swift
@@ -10,30 +10,32 @@ import UIKit
 class ViewController: UIViewController {
     private let shopService = ShopDataService()
     private var selecteLanguage = Language.korean
-    private var selectedMenu = 0
+    private var selectedMenu = -1
 
-	let shopView = ShopView()
-	var shopData = [CategoryData]()
+    let shopView = ShopView()
+    var shopData = [CategoryData]()
 
-	private lazy var dataSource = makeCollectionViewDataSource(shopView.shopCollectionView)
+    private lazy var dataSource = makeCollectionViewDataSource(shopView.shopCollectionView)
 
-	override func loadView() {
-		view = shopView
-	}
+    override func loadView() {
+        view = shopView
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-		shopView.shopCollectionView.delegate = self
-        loadKrmenu()
+        shopView.shopCollectionView.delegate = self
+        loadmenu()
     }
 
-    func loadKrmenu() {
+    func loadmenu() {
         shopService.loadMenuData(language: selecteLanguage) { result in
             switch result {
             case .success(let categorys):
                 DispatchQueue.main.async {
-					self.shopData = categorys
-                    self.updateData(self.shopData[self.selectedMenu].menus)
+                    self.shopData = categorys
+                    self.shopView.setCategoryButtonsConfigure(self.shopData)
+                    self.setupCategoryButtons()
+                    self.updateSelectedMenuData()
                 }
 
             case .failure(let error):
@@ -49,38 +51,77 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: UICollectionViewDelegate {
-	func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-		guard let shopItem = dataSource.itemIdentifier(for: indexPath) else {
-			return
-		}
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let shopItem = dataSource.itemIdentifier(for: indexPath) else {
+            return
+        }
 
-		print("touch \(shopItem.name)")
-	}
+        print("touch \(shopItem.name)")
+    }
 }
 
 extension ViewController {
-	private func updateData(_ data: [MenuData]) {
-		var snapshot = NSDiffableDataSourceSnapshot<Int, MenuData>()
-		snapshot.appendSections([0])
-		snapshot.appendItems(data, toSection: 0)
-		dataSource.apply(snapshot)
+    private func makecategoryButtons() {
+        shopView.setCategoryButtonsConfigure(shopData)
+    }
 
-		shopView.pageControl.numberOfPages = Int(ceil(Double(data.count) / 6.0))
-	}
+    // 전체 카테고리 처리를 위한 함수
+    private func updateSelectedMenuData() {
+        if selectedMenu == -1 {
+            let allMenus = shopData.flatMap { $0.menus }
+            updateData(allMenus)
+        } else {
+            updateData(shopData[selectedMenu].menus)
+        }
+    }
 
-	private func makeCollectionViewDataSource(
-		_ collectionView: UICollectionView) -> UICollectionViewDiffableDataSource<Int, MenuData> {
-			let cellRegistration = UICollectionView.CellRegistration<ShopCell, MenuData> { cell, _, item in
-				cell.configure(item: item)
-			}
+    private func updateData(_ data: [MenuData]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Int, MenuData>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(data, toSection: 0)
+        dataSource.apply(snapshot)
 
-			return UICollectionViewDiffableDataSource(collectionView: collectionView) { collectionView, indexPath, item in
-				collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)
-			}
-		}
+        shopView.pageControl.numberOfPages = Int(ceil(Double(data.count) / 6.0))
+    }
+
+    private func makeCollectionViewDataSource(
+        _ collectionView: UICollectionView) -> UICollectionViewDiffableDataSource<Int, MenuData> {
+            let cellRegistration = UICollectionView.CellRegistration<ShopCell, MenuData> { cell, _, item in
+                cell.configure(item: item)
+            }
+
+            return UICollectionViewDiffableDataSource(collectionView: collectionView) { collectionView, indexPath, item in
+                collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item)
+            }
+        }
+    // 카테고리 버튼에 액션을 연결하고, 현재 선택된 메뉴 상태를 초기 설정
+    private func setupCategoryButtons() {
+            shopView.categorySteckView.arrangedSubviews.forEach {
+                guard let button = $0 as? UIButton else { return }
+                button.addTarget(self, action: #selector(categoryButtonTapped(_:)), for: .touchUpInside)
+            }
+            updateCategorySelection(for: selectedMenu)
+        }
+
+    // 선택된 메뉴를 업데이트하고 해당 메뉴에 맞는 데이터를 표시
+    @objc private func categoryButtonTapped(_ sender: UIButton) {
+        selectedMenu = sender.tag
+        updateCategorySelection(for: selectedMenu)
+        updateSelectedMenuData()
+        print("선택된 카테고리 태그: \(selectedMenu)")
+    }
+
+    // 선택된 카테고리 버튼의 텍스트 색상을 변경
+    private func updateCategorySelection(for tag: Int) {
+        shopView.categorySteckView.arrangedSubviews.forEach {
+            guard let button = $0 as? UIButton else { return }
+            let isSelected = (button.tag == tag)
+            button.setTitleColor(isSelected ? .systemBlue : .label, for: .normal)
+        }
+    }
 }
 
 @available(iOS 17.0, *)
 #Preview {
-	ViewController()
+    ViewController()
 }


### PR DESCRIPTION
## 📋 PR 타입
- [x] Feat
- [ ] Fix
- [ ] Docs
- [ ] Style
- [ ] Refactor
- [ ] Add
- [ ] Chore

<br>

## 🔗 관련된 이슈
Closes #34 

<br>

## 🛠️ 작업 내용
<br>
하단에 담은 상품 총 금액과 장바구니보기 버튼, 담은 상품 개수 표시 및 상품이 표시되는 뷰와 분리를 위해 상단과 하단에 topSeparatorView,bottomSeparatorView를 추가하여 시각적 분리를 하였습니다.

## ✅ 체크리스트
- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

<br>

## 📸 스크린샷
<br>
<img width="361" alt="스크린샷 2025-06-30 02 22 59" src="https://github.com/user-attachments/assets/2e0e510e-2651-4ca3-8dbd-f91caefec82e" />


## 💬 리뷰어에게
full 받으실때 상단 카테고리바 먼저 머지후 풀 받고 하단 장바구니보기 뷰 머지후 full 받는걸 추천드립니다!