### PR TITLE
🚨 Fix: 상품을 담으면 총금액라벨과 장바구니보기 버튼이 뭉개지는 버그

### DIFF
--- a/Bbik/Source/View/ShopView.swift
+++ b/Bbik/Source/View/ShopView.swift
@@ -74,7 +74,7 @@ final class ShopView: UIView {
 
     let bottomStackView = UIStackView().then {
         $0.axis = .horizontal
-        $0.distribution = .fillProportionally
+        $0.distribution = .fillEqually
         $0.spacing = 12
     }
 

--- a/Bbik/Source/ViewController/ViewController.swift
+++ b/Bbik/Source/ViewController/ViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class ViewController: UIViewController {
     private let shopService = ShopDataService()
+
     private var selectedMenu = -1
     private var cartCount = 0
     private var totalPrice: Int = 0


### PR DESCRIPTION
Closes #55

## 📋 PR 타입
- [ ] Feat
- [x] Fix
- [ ] Docs
- [ ] Style
- [ ] Refactor
- [ ] Add
- [ ] Chore

<br>

## 🔗 관련된 이슈
Closes #55 

<br>

## 🛠️ 작업 내용
<br>
버튼과 라벨이 뭉개지는거 수정완료 했습니다

## ✅ 체크리스트
- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?

<br>

## 📸 스크린샷
<br>

![Simulator Screenshot - iPhone 16 Pro - 2025-06-30 at 20 02 18](https://github.com/user-attachments/assets/8ddb0c45-19bd-402f-888b-aee4cd15a535)

## 💬 리뷰어에게
